### PR TITLE
A match term evaluates to bool

### DIFF
--- a/reql/types.lisp
+++ b/reql/types.lisp
@@ -119,6 +119,7 @@
                      +term-term-type-contains+
                      +term-term-type-is-empty+
                      +term-term-type-has-fields+
+                     +term-term-type-match+
                      +term-term-type-any+
                      +term-term-type-all+
                      +term-term-type-during+)


### PR DESCRIPTION
I get a bool type error when trying

```
(:&& (:match (:attr booking "number") "^1406")
        (:attr booking "requiresTaxInvoiceP") t)
```

but something similar works fine using the JS driver and the docs on REQL match say you get an object for success and null on fail makes me wonder if this is reasonable...?  But am feeling my way in the dark inside `types.lisp`.  Is there a document or some rethinkdb JS/Python code somewhere that helps work out what goes in there or are we guessing somewhat?
