### PR TITLE
Added index option to distinct and fixed package lock warning on sbcl

### DIFF
--- a/reql/commands.lisp
+++ b/reql/commands.lisp
@@ -42,7 +42,7 @@
             (cmd-op cmd)
             (cmd-args cmd))
     (yason:encode (cmd-options cmd) s)))
-            
+
 (defmethod yason:encode ((cmd reql-cmd) &optional (stream *standard-output*))
   (yason:with-output (stream)
     (yason:with-array ()
@@ -186,7 +186,7 @@
 (defcommand (40 concatmap) (sequence function))
 (defcommand (41 order-by) (sequence fields &key index) :arrays (fields))
 (defcommand (41 order-by :defun nil) (sequence &rest fields))
-(defcommand (42 distinct) (sequence))
+(defcommand (42 distinct) (sequence &key index))
 (defcommand (43 count) (sequence))
 (defcommand (86 is-empty) (sequence))
 (defcommand (44 union) (&rest sequences))
@@ -331,4 +331,3 @@
 (defcommand (167 fill) (geo))
 (defcommand (168 get-nearest) (table geo &key index max-results max-dist geo-system unit))
 (defcommand (171 polygon-sub) (geo1 geo2))
-

--- a/reql/commands.lisp
+++ b/reql/commands.lisp
@@ -208,7 +208,7 @@
 (defcommand (85 splice-at) (array1 index array2))
 
 (defcommand (51 coerce-to) (val string))
-(defcommand (52 type-of) (val))
+(defcommand (52 typeof) (val))
 
 (defcommand (53 update) (selection object/function &key non-atomic durability return-changes))
 (defcommand (54 delete) (selection &key durability return-changes))
@@ -343,4 +343,3 @@
 
 (defun expr (lisp-obj)
   (cmd-arg lisp-obj))
-


### PR DESCRIPTION
The ql2.proto file doesn't mention it, but the JS API allows you to specify an index for the the distinct operation when used against a table.
Also with the latest code from v1.16.x branch I get a nasty warning when compiling about TYPE-OF.